### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/Tyrowin/gochat/security/code-scanning/9](https://github.com/Tyrowin/gochat/security/code-scanning/9)

The best way to fix the problem is to add a `permissions` block at the workflow root (for all jobs), or at the job level for jobs that require permissions deviating from the workflow default. Since the `notify` job (and likely most jobs in this workflow) do not need write access, set `contents: read` at the root, which is the strictest reasonable setting. If any job requires additional permissions (such as uploading SARIF results in `docker-scan` via `codeql-action/upload-sarif`), set those specific permissions for individual jobs. For now, this fix will add the recommended block at the top level of `.github/workflows/ci.yml`, which is best practice and addresses the CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
