### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-report-card-refresh.yml
+++ b/.github/workflows/go-report-card-refresh.yml
@@ -1,4 +1,5 @@
 name: Go Report Card Refresh
+permissions: {}
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Tyrowin/gochat/security/code-scanning/1](https://github.com/Tyrowin/gochat/security/code-scanning/1)

To fix the problem, add a `permissions` block at the workflow or job level to explicitly restrict the permissions granted to the workflow. Since the job simply makes a web request and does not interact with the repository, the minimal permissions setting is `permissions: {}`, which sets all permissions to `none`. This can be set at the workflow root (top-level) or job level. The best practice is to add the `permissions` block at the top just below `name:` and before `on:`, ensuring that no jobs can escalate permissions unless explicitly overridden.

**File/region to change:** At the top of `.github/workflows/go-report-card-refresh.yml`, add the `permissions: {}` block under the workflow name.

**What is needed:** No imports or new methods are needed, just the addition of a `permissions: {}` YAML block at the correct location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
